### PR TITLE
Corrige la hauteur des pages dans l’atelier

### DIFF
--- a/assets/styles/styles.css
+++ b/assets/styles/styles.css
@@ -95,11 +95,14 @@ body {
   font-family: Arial, Helvetica, sans-serif;
   font-size: 1.2rem;
   background-color: #ffe7b3;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
 }
 
 main {
   padding-bottom: 2rem;
-  min-height: 83vh;
+  flex: 1;
 }
 
 footer {


### PR DESCRIPTION
Occupe toute la hauteur avec flex plutôt qu’une hauteur min fixe, ce qui cause parfois un dépassement vertical inutile.

Avant:
<img width="916" height="702" alt="screenshot_2026-06-27_10-58-54" src="https://github.com/user-attachments/assets/60cfe1da-c903-4922-94ed-92a88bf9675e" />

Après:
<img width="916" height="702" alt="screenshot_2026-06-27_10-59-50" src="https://github.com/user-attachments/assets/ece86345-97e4-4e35-a861-95974973dc4f" />
